### PR TITLE
Setting up the necessary classes and interfaces for the Reply Thread Use Case

### DIFF
--- a/src/main/java/use_case/reply_thread/ReplyThreadInputBoundary.java
+++ b/src/main/java/use_case/reply_thread/ReplyThreadInputBoundary.java
@@ -1,0 +1,12 @@
+package use_case.reply_thread;
+
+/**
+ * Input Boundary for Reply Thread use case.
+ */
+public interface ReplyThreadInputBoundary {
+    /**
+     * Executes the Reply Thread use case.
+     * @param replyThreadInputData the input data
+     */
+    void execute(ReplyThreadInputData replyThreadInputData);
+}

--- a/src/main/java/use_case/reply_thread/ReplyThreadInputData.java
+++ b/src/main/java/use_case/reply_thread/ReplyThreadInputData.java
@@ -1,0 +1,5 @@
+package use_case.reply_thread;
+
+public class ReplyThreadInputData {
+    // TODO: Imeplement the input data
+}

--- a/src/main/java/use_case/reply_thread/ReplyThreadInteractor.java
+++ b/src/main/java/use_case/reply_thread/ReplyThreadInteractor.java
@@ -1,0 +1,5 @@
+package use_case.reply_thread;
+
+public class ReplyThreadInteractor {
+    // TODO: Implement the Interactor
+}

--- a/src/main/java/use_case/reply_thread/ReplyThreadOutputBoundary.java
+++ b/src/main/java/use_case/reply_thread/ReplyThreadOutputBoundary.java
@@ -1,0 +1,18 @@
+package use_case.reply_thread;
+
+/**
+ * Output Boundary for Reply Thread use case.
+ */
+public interface ReplyThreadOutputBoundary {
+    /**
+     * Prepares the success view for the Reply Thread use case.
+     * @param replyThreadOutputData the output data
+     */
+    void prepareSuccessView(ReplyThreadOutputData replyThreadOutputData);
+
+    /**
+     * Prepares the failure view for the Reply Thread use case.
+     * @param errorMessage explanation of the error
+     */
+    void prepareFailureView(String errorMessage);
+}

--- a/src/main/java/use_case/reply_thread/ReplyThreadOutputData.java
+++ b/src/main/java/use_case/reply_thread/ReplyThreadOutputData.java
@@ -1,0 +1,5 @@
+package use_case.reply_thread;
+
+public class ReplyThreadOutputData {
+    // TODO: Implement the Output data
+}

--- a/src/main/java/use_case/reply_thread/ReplyThreadUserDataAccessInterface.java
+++ b/src/main/java/use_case/reply_thread/ReplyThreadUserDataAccessInterface.java
@@ -1,0 +1,8 @@
+package use_case.reply_thread;
+
+/**
+ * The DAO interface for the Reply Thread use case.
+ */
+public interface ReplyThreadUserDataAccessInterface {
+    // TODO: Implement this when the use case is more developed
+}


### PR DESCRIPTION
As mentioned in the title, this PR is for initializing the reply thread use case in an abstract sense. 
I also added some package folders, which comply with the Clean Architecture that the team can rely on later.